### PR TITLE
Add initial documentation and local install config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,74 @@
 # provider-template
+
+`provider-template` is a minimal [Crossplane](https://crossplane.io/) Provider
+that is meant to be used as a template for implementing new Providers. It comes
+with the following features that are meant to be refactored:
+
+- A `Provider` resource type that only points to a credentials `Secret`.
+- A `MyType` resource type that serves as an example managed resource.
+- A managed resource controller that reconciles `MyType` objects and simply
+  prints their configuration in its `Observe` method.
+
+## Install
+
+If you would like to install `provider-template` without modifications create
+the following `ClusterStackInstall` in a Kubernetes cluster where Crossplane is
+installed:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: template
+---
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: ClusterStackInstall
+metadata:
+  name: provider-template
+  namespace: template
+spec:
+  package: "crossplanebook/provider-template:latest"
+```
+
+## Developing
+
+Run against a Kubernetes cluster:
+```
+make run
+```
+
+Install `latest` into Kubernetes cluster where Crossplane is installed:
+```
+make install
+```
+
+Install local build into [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
+cluster where Crossplane is installed:
+```
+make install-local
+```
+
+Build, push, and install:
+```
+make all
+```
+
+Build image:
+```
+make image
+```
+
+Push image:
+```
+make push
+```
+
+Build binary:
+```
+make build
+```
+
+Build stack package:
+```
+make build-stack-package
+```

--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -3,10 +3,17 @@ title: Template Provider
 
 overviewShort: The Template Crossplane Provider allows you to bootstrap your own provider.
 overview: |-
-  
+  The Template Crossplane Provider is a minimal Crossplane Provider that serves
+  as a starting point for building new Crossplane Providers. It is meant to be
+  refactored for your use-case.
 # Markdown description of this entry
 readme: |
- 
+  `provider-template` is a minimal Crossplane Provider that is meant to be used
+  as a template for implementing new Providers. It comes with the following features
+  that are meant to be refactored:
+  - A `Provider` resource type that only points to a credentials `Secret`.
+  - A `MyType` resource type that serves as an example managed resource.
+  - A managed resource controller that reconciles `MyType` objects and simply prints their configuration in its `Observe` method.
 
 # Maintainer names and emails.
 maintainers:

--- a/config/stack/sample/local.install.stack.yaml
+++ b/config/stack/sample/local.install.stack.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: template
+---
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: ClusterStackInstall
+metadata:
+  name: provider-template
+  namespace: template
+spec:
+  package: "provider-template:local"
+  imagePullPolicy: Never


### PR DESCRIPTION
Updates documentation to include `make` commands and also adds support for local dev with [kind](https://kind.sigs.k8s.io/).