### PR TITLE
issue template: adds some basic generic issue templates to the provid…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Help us diagnose and fix bugs in Crossplane
+labels: bug
+---
+<!--
+Thank you for helping to improve Crossplane!
+
+Please be sure to search for open issues before raising a new one. We use issues for bug reports and feature requests. Please find us at https://slack.crossplane.io for questions, support, and discussion.
+-->
+
+### What happened?
+<!--
+Please let us know what behaviour you expected and how Crossplane diverged from that behaviour.
+-->
+
+
+### How can we reproduce it?
+<!--
+Help us to reproduce your bug as succinctly and precisely as possible. Artifacts such as example manifests or a script that triggers the issue are highly appreciated!
+-->
+
+### What environment did it happen in?
+Crossplane version: 
+Provider version: 
+
+<!--
+Include at least the version or commit of Crossplane you were running. Consider also including your:
+
+* Cloud provider or hardware configuration
+* Kubernetes version (use `kubectl version`)
+* Kubernetes distribution (e.g. Tectonic, GKE, OpenShift)
+* OS (e.g. from /etc/os-release)
+* Kernel (e.g. `uname -a`)
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Help us make Crossplane more useful
+labels: enhancement
+---
+<!--
+Thank you for helping to improve Crossplane!
+
+Please be sure to search for open issues before raising a new one. We use issues for bug reports and feature requests. Please find us at https://slack.crossplane.io for questions, support, and discussion.
+-->
+
+### What problem are you facing?
+<!--
+Please tell us a little about your use case - it's okay if it's hypothetical! Leading with this context helps frame the feature request so we can ensure we implement it sensibly.
+--->
+
+### How could this provider help solve your problem?
+<!--
+Let us know how you think Crossplane could help with your use case. 
+-->


### PR DESCRIPTION
This PR adds some basic generic templates to the provider-template. This is will be useful so that all future provider templates do not need to begin the process from scratch when starting development on a Provider.

Signed-off-by: Krish Chowdhary <krish@redhat.com>