### PR TITLE
Deprecate repo in favor of crossplane/provider-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This repository is DEPRECATED. It has been moved to [`crossplane/provider-template`](https://github.com/crossplane/provider-template), where it will continue to be maintained.
+
 # provider-template
 
 `provider-template` is a minimal [Crossplane](https://crossplane.io/) Provider


### PR DESCRIPTION
Adds deprecation notice and link to provider-template.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #7 